### PR TITLE
Remove marking-definition definition_type enum

### DIFF
--- a/schemas/common/marking-definition.json
+++ b/schemas/common/marking-definition.json
@@ -15,8 +15,7 @@
     },
     "definition_type": {
       "type": "string",
-      "description": "The definition_type property identifies the type of Marking Definition.",
-      "enum": ["statement", "tlp"]
+      "description": "The definition_type property identifies the type of Marking Definition."
     },
     "definition": {
       "oneOf": [


### PR DESCRIPTION
Restricting definition_type to one of ['statement', 'tlp'] is a SHOULD requirement, not a MUST requirement and thus should not be included in the schemas.

Close #1. 