### PR TITLE
Updated idioms/examples to RC3, fixed timestamps, removed cybox references

### DIFF
--- a/examples/apt1.json
+++ b/examples/apt1.json
@@ -221,7 +221,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "HTRAN Hop Point Accessor",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "ipv4addr:value = '223.166.0.0/15'",
       "labels": [
         "malicious-activity"
@@ -241,7 +241,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "HTRAN Hop Point Accessor",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "ipv4addr:value = '58.246.0.0/15'",
       "labels": [
         "malicious-activity"
@@ -261,7 +261,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "HTRAN Hop Point Accessor",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "ipv4addr:value = '112.64.0.0/15'",
       "labels": [
         "malicious-activity"
@@ -281,7 +281,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "HTRAN Hop Point Accessor",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "ipv4addr:value = '139.226.0.0/15'",
       "labels": [
         "malicious-activity"
@@ -301,7 +301,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "FQDN hugesoft.org",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "domain-name:value = 'hugesoft.org'",
       "labels": [
         "malicious-activity"
@@ -315,7 +315,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "FQDN arrowservice.net",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "domain-name:value = 'arrowservice.net'",
       "labels": [
         "malicious-activity"
@@ -329,7 +329,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "FQDN msnhome.org",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "domain-name:value = 'msnhome.org'",
       "labels": [
         "malicious-activity"
@@ -343,7 +343,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "Appendix E MD5 hash '001dd76872d80801692ff942308c64e6'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "file:hashes.md5 = '001dd76872d80801692ff942308c64e6'",
       "labels": [
         "malicious-activity"
@@ -357,7 +357,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "Appendix E MD5 hash '002325a0a67fded0381b5648d7fe9b8e'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "file:hashes.md5 = '002325a0a67fded0381b5648d7fe9b8e'",
       "labels": [
         "malicious-activity"
@@ -371,7 +371,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "Appendix E MD5 hash '00dbb9e1c09dbdafb360f3163ba5a3de'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "file:hashes.md5 = '00dbb9e1c09dbdafb360f3163ba5a3de'",
       "labels": [
         "malicious-activity"
@@ -385,8 +385,8 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "Appendix F SSL Certificate for serial number '(Negative)4c:0b:1d:19:74:86:a7:66:b4:1a:bf:40:27:21:76:28'",
-      "pattern_lang": "cybox",
-      "pattern": "x509-certificate:issuer = 'CN=WEBMAIL' AND x509-certificate:serial_number = '(Negative)4c:0b:1d:19:74:86:a7:66:b4:1a:bf:40:27:21:76:28'",
+      "pattern_lang": "stix",
+      "pattern": "x509-certificate:issuer = 'CN=WEBMAIL' AND x509-certificate:serial_number = '4c:0b:1d:19:74:86:a7:66:b4:1a:bf:40:27:21:76:28'",
       "labels": [
         "malicious-activity"
       ],
@@ -399,7 +399,7 @@
       "created": "2015-05-15T09:00:00.000000Z",
       "modified": "2015-05-15T09:00:00.000000Z",
       "name": "Appendix F SSL Certificate for serial number '0e:97:88:1c:6c:a1:37:96:42:03:bc:45:42:24:75:6c'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "pattern": "x509-certificate:issuer = 'CN=LM-68AB71FBD8F5' AND x509-certificate:serial_number = '0e:97:88:1c:6c:a1:37:96:42:03:bc:45:42:24:75:6c'",
       "labels": [
         "malicious-activity"

--- a/examples/idioms/course-of-action-to-block-network-traffic.json
+++ b/examples/idioms/course-of-action-to-block-network-traffic.json
@@ -23,13 +23,12 @@
       "first_observed": "2015-12-21T19:00:00Z",
       "last_observed": "2015-12-21T20:00:00Z",
       "number_observed": 11,
-      "objects": [
-        {
-          "type": "ipv4addr-object",
-          "id": "ipv4addr-object--1",
+      "objects": {
+        "0": {
+          "type": "ipv4addr",
           "value:": "10.10.10.10"
         }
-      ]
+      }
     }
   ],
   "relationships": [

--- a/examples/idioms/course-of-action-to-block-network-traffic.json
+++ b/examples/idioms/course-of-action-to-block-network-traffic.json
@@ -23,17 +23,13 @@
       "first_observed": "2015-12-21T19:00:00Z",
       "last_observed": "2015-12-21T20:00:00Z",
       "number_observed": 11,
-      "cybox": {
-        "type": "cybox-container",
-        "spec_version": "3.0",
-        "objects": [
-          {
-            "type": "ipv4addr-object",
-            "id": "ipv4addr-object--1",
-            "value:": "10.10.10.10"
-          }
-        ]
-      }
+      "objects": [
+        {
+          "type": "ipv4addr-object",
+          "id": "ipv4addr-object--1",
+          "value:": "10.10.10.10"
+        }
+      ]
     }
   ],
   "relationships": [

--- a/examples/idioms/file-hash-reputation.json
+++ b/examples/idioms/file-hash-reputation.json
@@ -14,7 +14,7 @@
         "malicious-activity"
       ],
       "pattern": "file:hashes.SHA-256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "valid_from": "2015-12-21T19:59:17Z"
     }
   ],

--- a/examples/idioms/identifying-a-threat-actor-profile.json
+++ b/examples/idioms/identifying-a-threat-actor-profile.json
@@ -7,8 +7,8 @@
       "type": "threat-actor",
       "id": "threat-actor--dfaa8d77-07e2-4e28-b2c8-92e9f7b04428",
       "version": 1,
-      "created": "2014-11-19 23:39:03.893348",
-      "modified": "2014-11-19 23:39:03.893348",
+      "created": "2014-11-19T23:39:03.893348Z",
+      "modified": "2014-11-19T23:39:03.893348Z",
       "name": "Disco Team Threat Actor Group",
       "labels": [
         "crime-syndicate"
@@ -20,9 +20,9 @@
       "type": "identity",
       "id": "identity--733c5838-34d9-4fbf-949c-62aba761184c",
       "version": 1,
-      "created": "2016-08-23T18:05:49.307000",
-      "modified": "2016-08-23T18:05:49.307000",
-      "name": "Disco Tean",
+      "created": "2016-08-23T18:05:49.307000Z",
+      "modified": "2016-08-23T18:05:49.307000Z",
+      "name": "Disco Team",
       "identity_class": "organization",
       "regions": [
         "California"
@@ -38,8 +38,8 @@
       "type": "relationship",
       "id": "relationship--966c5838-34d9-4fbf-949c-62aba7611837",
       "version": 1,
-      "created": "2016-08-23T18:05:49.307000",
-      "modified": "2016-08-23T18:05:49.307000",
+      "created": "2016-08-23T18:05:49.307000Z",
+      "modified": "2016-08-23T18:05:49.307000Z",
       "relationship_type": "attributed-to",
       "source_ref": "threat-actor--dfaa8d77-07e2-4e28-b2c8-92e9f7b04428",
       "target_ref": "identity--733c5838-34d9-4fbf-949c-62aba761184c"

--- a/examples/idioms/indicator-for-c2-ip-address.json
+++ b/examples/idioms/indicator-for-c2-ip-address.json
@@ -14,7 +14,7 @@
         "malicious-activity"
       ],
       "pattern": "ipv4addr:value = '10.0.0.0'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "valid_from": "2014-05-08T09:00:00.000000Z"
     }
   ]

--- a/examples/idioms/indicator-for-malicious-URL.json
+++ b/examples/idioms/indicator-for-malicious-URL.json
@@ -14,7 +14,7 @@
       ],
       "name": "Malicious site hosting downloader",
       "pattern": "url:value = 'http://x4z9arb.cn/4712'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "valid_from": "2014-06-29T13:49:37.079000Z"
     }
   ]

--- a/examples/idioms/indicator-to-campaign-relationship.json
+++ b/examples/idioms/indicator-to-campaign-relationship.json
@@ -23,7 +23,7 @@
         "malicious-activity"
       ],
       "pattern": "ipv4addr.value = '10.0.0.0'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "valid_from": "2014-09-09T19:58:39.609000Z"
     }
   ],

--- a/examples/idioms/kill-chain.json
+++ b/examples/idioms/kill-chain.json
@@ -7,13 +7,13 @@
       "type": "indicator",
       "id": "indicator--f33c2b75-aa60-4ffb-9829-3746ef233311",
       "version": 1,
-      "created": "2014-10-21 21:10:09.423000+00:00",
-      "modified": "2014-10-21 21:10:09.423000+00:00",
-      "valid_from": "2014-10-21 21:10:09.423000+00:00",
+      "created": "2014-10-21T21:10:09.423000Z",
+      "modified": "2014-10-21T21:10:09.423000Z",
+      "valid_from": "2014-10-21T21:10:09.423000Z",
       "kill_chain_phases": [
         {
-          "kill_chain_name": "LM Cyber Kill Chain",
-          "phase_name": "Actions on Objectives"
+          "kill_chain_name": "lockheed-martin-cyber-kill-chain",
+          "phase_name": "actions-on-objectives"
         }
       ]
     }

--- a/examples/idioms/linking-an-indicator-to-kill-chain-phase.json
+++ b/examples/idioms/linking-an-indicator-to-kill-chain-phase.json
@@ -15,12 +15,12 @@
       ],
       "description": "Resident binary which implements infostealing and credit card grabber",
       "pattern": "file:file_name = 'crypt1.exe'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "valid_from": "2014-10-09T21:38:50.631509Z",
       "kill_chain_phases": [
         {
-          "kill_chain_name": "Organization-specific Kill Chain",
-          "phase_name": "Infect Machine"
+          "kill_chain_name": "organization-specific-kill-chain",
+          "phase_name": "infect-machine"
         }
       ]
     }

--- a/examples/idioms/malicious-e-mail-indicator-with-attachment.json
+++ b/examples/idioms/malicious-e-mail-indicator-with-attachment.json
@@ -12,8 +12,8 @@
       "name": "Phishing",
       "external-references": [
         {
-          "source_name": "CAPEC",
-          "external_id": "capec-98"
+          "source_name": "capec",
+          "external_id": "CAPEC-98"
         }
       ]
     }
@@ -31,7 +31,7 @@
       ],
       "valid_from": "2014-10-31T15:52:13.127931Z",
       "pattern": "email-message:header.subject MATCHES  /^[IMPORTANT] Please Review Before/",
-      "pattern_lang": "cybox"
+      "pattern_lang": "stix"
     },
     {
       "type": "indicator",
@@ -45,7 +45,7 @@
       ],
       "valid_from": "2014-10-31T15:52:13.127931Z",
       "pattern": "email-message:header.subject MATCHES  /^[IMPORTANT] Please Review Before/",
-      "pattern_lang": "cybox"
+      "pattern_lang": "stix"
     },
     {
       "type": "indicator",
@@ -59,7 +59,7 @@
       ],
       "valid_from": "2014-10-31T15:52:13.127931Z",
       "pattern": "email-message:attachments.name MATCHES  /^Final Report.+\\.exe$/",
-      "pattern_lang": "cybox"
+      "pattern_lang": "stix"
     }
   ],
   "relationships": [

--- a/examples/idioms/malware-characterization-using-maec.json
+++ b/examples/idioms/malware-characterization-using-maec.json
@@ -7,8 +7,8 @@
       "type": "malware",
       "id": "malware--bce53fe4-d5ac-4f0b-9675-d728a60675a2",
       "version": 1,
-      "created": "2016-08-23T18:05:49.371000",
-      "modified": "2016-08-23T18:05:49.371000",
+      "created": "2016-08-23T18:05:49.371000Z",
+      "modified": "2016-08-23T18:05:49.371000Z",
       "name": "Poison Ivy Variant v4392-acc",
       "labels": [
         "remote-access-trojan"

--- a/examples/idioms/malware-indicator-for-file-hash.json
+++ b/examples/idioms/malware-indicator-for-file-hash.json
@@ -14,7 +14,7 @@
         "malicious-activity"
       ],
       "pattern": "file:hashes.SHA-256 = 'ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c'",
-      "pattern_lang": "cybox",
+      "pattern_lang": "stix",
       "valid_from": "2014-02-20T09:00:00.000000Z"
     }
   ],

--- a/examples/idioms/snort-test-mechanism.json
+++ b/examples/idioms/snort-test-mechanism.json
@@ -6,8 +6,8 @@
     {
       "type": "vulnerability",
       "id": "vulnerability--0742cf0c-7c9a-4a4a-9156-7c501a51528c",
-      "created": "2014-06-20 15:16:56.986650",
-      "modified": "2014-06-20 15:16:56.986650",
+      "created": "2014-06-20T15:16:56.986650Z",
+      "modified": "2014-06-20T15:16:56.986650Z",
       "version": 1,
       "name": "Heartbleed",
       "external_references": [
@@ -23,12 +23,12 @@
       "type": "indicator",
       "id": "indicator--567b201c-4fd5-4bde-a5db-42abc340807b",
       "version": 1,
-      "created": "2014-06-20 15:16:56.987616",
-      "modified": "2014-06-20 15:16:56.987616",
+      "created": "2014-06-20T15:16:56.987616Z",
+      "modified": "2014-06-20T15:16:56.987616Z",
       "pattern": "alert tcp any any -> any any (msg:\\\"FOX-SRT - Flowbit - TLS-SSL Client Hello\\\"; flow:established; dsize:< 500; content:\\\"|16 03|\\\"; depth:2; byte_test:1, <=, 2, 3; byte_test:1, !=, 2, 1; content:\\\"|01|\\\"; offset:5; depth:1; content:\\\"|03|\\\"; offset:9; byte_test:1, <=, 3, 10; byte_test:1, !=, 2, 9; content:\\\"|00 0f 00|\\\"; flowbits:set,foxsslsession; flowbits:noalert; threshold:type limit, track by_src, count 1, seconds 60; reference:cve,2014-0160; classtype:bad-unknown; sid: 21001130; rev:9;), alert tcp any any -> any any (msg:\\\"FOX-SRT - Suspicious - TLS-SSL Large Heartbeat Response\\\"; flow:established; flowbits:isset,foxsslsession; content:\\\"|18 03|\\\"; depth: 2; byte_test:1, <=, 3, 2; byte_test:1, !=, 2, 1; byte_test:2, >, 200, 3; threshold:type limit, track by_src, count 1, seconds 600; reference:cve,2014-0160; classtype:bad-unknown; sid: 21001131; rev:5;)",
       "pattern_lang": "snort",
       "name": "Snort Signature for Heartbleed",
-      "valid_from": "2014-06-20 15:16:56.987616",
+      "valid_from": "2014-06-20T15:16:56.987616Z",
       "labels": [
         "malicious-activity"
       ],
@@ -40,8 +40,8 @@
       "type": "identity",
       "id": "identity--a0740d84-9fcd-44af-9033-94e76a53201e",
       "version": 1,
-      "created": "2014-06-20 15:16:56.987616",
-      "modified": "2014-06-20 15:16:56.987616",
+      "created": "2014-06-20T15:16:56.987616Z",
+      "modified": "2014-06-20T15:16:56.987616Z",
       "name": "FOX IT",
       "identity_class": "organization",
       "external_references": [
@@ -56,8 +56,8 @@
     {
       "type": "relationship",
       "id": "relationship--45178b68-3274-439f-a603-ec39b2db2490",
-      "created": "2016-08-23T18:05:49.400000",
-      "modified": "2016-08-23T18:05:49.400000",
+      "created": "2016-08-23T18:05:49.400000Z",
+      "modified": "2016-08-23T18:05:49.400000Z",
       "version": 1,
       "relationship_type": "related-to",
       "source_ref": "indicator--567b201c-4fd5-4bde-a5db-42abc340807b",

--- a/examples/idioms/threat-actor-leveraging-attack-patterns-and-malware.json
+++ b/examples/idioms/threat-actor-leveraging-attack-patterns-and-malware.json
@@ -12,8 +12,8 @@
       "name": "Poison Ivy Variant",
       "external-references": [
         {
-          "source_name": "CAPEC",
-          "external_id": "capec-98"
+          "source_name": "capec",
+          "external_id": "CAPEC-98"
         }
       ]
     }

--- a/examples/idioms/victim-targeting-by-sector.json
+++ b/examples/idioms/victim-targeting-by-sector.json
@@ -7,8 +7,8 @@
       "type": "identity",
       "id": "identity--dfd23353-167f-411c-a258-e08ec9d284af",
       "version": 1,
-      "created": "2016-08-23T18:05:49.414000",
-      "modified": "2016-08-23T18:05:49.414000",
+      "created": "2016-08-23T18:05:49.414000Z",
+      "modified": "2016-08-23T18:05:49.414000Z",
       "name": "Electricity and Industrial Control System",
       "description": "Electricity Sector and Industrial Control System Sector",
       "sectors": [

--- a/examples/idioms/yara-test-mechanism.json
+++ b/examples/idioms/yara-test-mechanism.json
@@ -7,13 +7,13 @@
       "type": "indicator",
       "id": "indicator--567b201c-4fd5-4bde-a5db-42abc340807a",
       "version": 1,
-      "created": "2014-06-20 15:16:56.987616",
-      "modified": "2014-06-20 15:16:56.987616",
+      "created": "2014-06-20T15:16:56.987616Z",
+      "modified": "2014-06-20T15:16:56.987616Z",
       "name": "silent_banker",
       "pattern": "\\nrule silent_banker : banker\\n{\\n    meta:\\n        description = \"This is just an example\"\\n        thread_level = 3\\n        in_the_wild = true\\n\\n    strings:\\n        $a = {6A 40 68 00 30 00 00 6A 14 8D 91}\\n        $b = {8D 4D B0 2B C1 83 C0 27 99 6A 4E 59 F7 F9}\\n        $c = \"UVODFRYSIHLNWPEJXQZAKCBGMT\"\\n\\n    condition:\\n        $a or $b or $c\\n}\\n",
       "pattern_lang": "yara",
       "description": "This is just an example.",
-      "valid_from": "2014-06-20 15:16:56.987616",
+      "valid_from": "2014-06-20T15:16:56.987616Z",
       "labels": [
         "malicious-activity"
       ],

--- a/schemas/sdos/observed-data.json
+++ b/schemas/sdos/observed-data.json
@@ -29,13 +29,14 @@
         },
         "number_observed": {
           "type": "integer",
-          "description": "The number of times the data represented in the cybox property was observed. This MUST be an integer between 1 and 999,999,999 inclusive.",
+          "description": "The number of times the data represented in the objects property was observed. This MUST be an integer between 1 and 999,999,999 inclusive.",
           "minimum": 1,
           "maximum": 999999999
         },
         "objects": {
-          "type": "array",
-          "description": "A dictionary of Cyber Observable Objects that describes the single 'fact' that was observed."
+          "type": "object",
+          "description": "A dictionary of Cyber Observable Objects that describes the single 'fact' that was observed.",
+          "minProperties": 1
         }
       }
     }

--- a/tests/sdos/indicator/simple.json
+++ b/tests/sdos/indicator/simple.json
@@ -1,14 +1,16 @@
 {
-    "type": "indicator",
-    "id": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
-    "created_by_ref": "source--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-    "created": "2016-04-06T20:03:48Z",
-    "modified": "2016-04-06T20:03:48Z",
-    "version": 1,
-    "labels": ["malicious-activity"],
-    "name": "Poison Ivy Malware",
-    "description": "This file is part of Poison Ivy",
-    "pattern": "file-object.hashes.md5 = '3773a88f65a5e780c8dff9cdc3a056f3'",
-    "pattern_lang": "cybox",
-    "valid_from": "2016-01-01T00:00:00Z"
+  "type": "indicator",
+  "id": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+  "created_by_ref": "source--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+  "created": "2016-04-06T20:03:48Z",
+  "modified": "2016-04-06T20:03:48Z",
+  "version": 1,
+  "labels": [
+    "malicious-activity"
+  ],
+  "name": "Poison Ivy Malware",
+  "description": "This file is part of Poison Ivy",
+  "pattern": "file:hashes.MD5 = '3773a88f65a5e780c8dff9cdc3a056f3'",
+  "pattern_lang": "stix",
+  "valid_from": "2016-01-01T00:00:00Z"
 }

--- a/tests/sdos/report/simple.json
+++ b/tests/sdos/report/simple.json
@@ -6,7 +6,11 @@
   "published": "2016-02-28T01:01:01.000Z",
   "version": 1,
   "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
-  "object_refs": ["identity--f431f809-377b-45e0-aa1c-6a4751cae5ff"],
+  "object_refs": [
+    "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff"
+  ],
   "name": "Some report",
-  "labels": ["threat-report"]
+  "labels": [
+    "threat-report"
+  ]
 }


### PR DESCRIPTION
-Adjusted idioms to work with RC3 specs
-Reformatted timestamps to be compliant with the timestamp format in the
specs
-Removed cybox instances
-Corrected kill chain phase and external-reference formats based on the
specs