### PR TITLE
Fix string literal escaping to match the spec

### DIFF
--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -127,7 +127,7 @@ BinaryLiteral :
   ;
 
 StringLiteral :
-  QUOTE ( ~'\'' | '\'\'' )* QUOTE
+  QUOTE ( ~['\\] | '\\\'' | '\\\\' )* QUOTE
   ;
 
 BoolLiteral :


### PR DESCRIPTION
This corresponds to cti-pattern-matcher [PR#15](https://github.com/oasis-open/cti-pattern-matcher/pull/15).