### PR TITLE
Fix WITHIN qualifier time units to agree with spec

### DIFF
--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -57,7 +57,7 @@ startStopQualifier
   ;
 
 withinQualifier
-  : WITHIN FloatLiteral SECONDS
+  : WITHIN (IntLiteral|FloatLiteral) SECONDS
   ;
 
 repeatedQualifier

--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -57,7 +57,7 @@ startStopQualifier
   ;
 
 withinQualifier
-  : WITHIN IntLiteral timeUnit
+  : WITHIN IntLiteral SECONDS
   ;
 
 repeatedQualifier
@@ -103,10 +103,6 @@ orderableLiteral
   | BinaryLiteral
   | HexLiteral
   | TimestampLiteral
-  ;
-
-timeUnit
-  : MILLISECONDS | SECONDS | MINUTES | HOURS | DAYS | MONTHS | YEARS
   ;
 
 IntLiteral :
@@ -157,13 +153,7 @@ LAST:  L A S T ;
 IN:  I N;
 START:  S T A R T ;
 STOP:  S T O P ;
-MILLISECONDS:  M I L L I S E C O N D S;
 SECONDS:  S E C O N D S;
-MINUTES:  M I N U T E S;
-HOURS:  H O U R S;
-DAYS:  D A Y S;
-MONTHS:  M O N T H S;
-YEARS:  Y E A R S;
 TRUE:  T R U E;
 FALSE:  F A L S E;
 WITHIN:  W I T H I N;

--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -57,7 +57,7 @@ startStopQualifier
   ;
 
 withinQualifier
-  : WITHIN IntLiteral SECONDS
+  : WITHIN FloatLiteral SECONDS
   ;
 
 repeatedQualifier


### PR DESCRIPTION
This is the grammar update corresponding to cti-pattern-matcher [PR#20](https://github.com/oasis-open/cti-pattern-matcher/pull/20).

- All time units in WITHIN qualifiers are removed except seconds
- WITHIN seconds counts may now be either ints or floats
