### PR TITLE
Fix binary-typed properties in Cyber Observable objects

### DIFF
--- a/schemas/common/binary.json
+++ b/schemas/common/binary.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "binary",
+  "description": "The ​binary data type represents a sequence of bytes. In order to allow pattern matching on custom objects, for all properties that use the binary type, the property name MUST end with '_bin'. The JSON MTI serialization represents this as a base64-­encoded string as specified in RFC4648​. Other serializations SHOULD use a native binary type, if available.",
+  "type": "string",
+  "pattern": "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$"
+}

--- a/schemas/common/cyber-observable-core.json
+++ b/schemas/common/cyber-observable-core.json
@@ -26,6 +26,9 @@
     }
   },
   "patternProperties": {
+    "^[a-z0-9_]{0,246}_bin$": {
+      "$ref": "../common/binary.json"
+    },
     "^[a-z0-9_]{3,250}$": {
       "anyOf": [
         {

--- a/schemas/observables/artifact.json
+++ b/schemas/observables/artifact.json
@@ -28,10 +28,7 @@
     {
       "properties": {
         "payload_bin": {
-          "type": "string",
-          "media": {
-            "binaryEncoding": "base64"
-          },
+          "$ref": "../common/binary.json",
           "description": "Specifies the binary data contained in the artifact as a base64-encoded string."
         },
         "hashes": {


### PR DESCRIPTION
`media: binaryEncoding` is only valid in JSON Hyper-Schema.

Found by oasis-open/cti-stix-validator#17