### PR TITLE
change START STOP timestamp to TimestampLiteral

### DIFF
--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -53,7 +53,7 @@ propTest
   ;
 
 startStopQualifier
-  : START StringLiteral STOP StringLiteral
+  : START TimestampLiteral STOP TimestampLiteral
   ;
 
 withinQualifier


### PR DESCRIPTION
Pattern validation was failing on the START STOP qualifier when the timestamp was in the format of
`START t'2016-06-01T00:00:00Z' STOP t'2016-06-01T01:11:11Z'`
The leading **t** in the timestamp was the culprit. Validation should work when the generated grammar files get incorporated into the pattern validator (https://github.com/oasis-open/cti-pattern-validator) .