### PR TITLE
New SDOs introduced in STIX 2.1 WD04

### DIFF
--- a/schemas/common/core.json
+++ b/schemas/common/core.json
@@ -15,7 +15,7 @@
       "not": {
         "enum": [
           "incident",
-          "infrastructure"
+          "action"
         ]
       }
     },

--- a/schemas/sdos/grouping.json
+++ b/schemas/sdos/grouping.json
@@ -1,0 +1,50 @@
+{
+  "id": "../sdos/grouping.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "grouping",
+  "description": "A Grouping object explicitly asserts that the referenced STIX Objects have a shared content.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../common/core.json"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `grouping`.",
+          "enum": [
+            "grouping"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^grouping--"
+        },
+        "name": {
+          "type": "string",
+          "description": "A name used to identify the Grouping."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description which provides more details and context about the Grouping, potentially including hte purpose and key characteristics."
+        },
+        "context": {
+          "type": "string",
+          "description": "A short description of the particular context shared by the content referenced by the Grouping."
+        },
+        "object_refs": {
+          "type": "array",
+          "description": "The STIX Objects (SDOs and SROs) that the note is being applied to.",
+          "items": {
+            "$ref": "../common/identifier.json"
+          },
+          "minItems": 1
+        }
+      }
+    }
+  ],
+  "required": [
+    "context"
+  ]
+}

--- a/schemas/sdos/infrastructure.json
+++ b/schemas/sdos/infrastructure.json
@@ -1,0 +1,81 @@
+{
+  "id": "../sdos/infrastructure.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "infrastructure",
+  "description": "Infrastructure objects describe systems, software services, and associated physical or virtual resources.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../common/core.json"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `infrastructure`.",
+          "enum": [
+            "infrastructure"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^infrastructure--"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name used to identify the Infrastructure."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description that provides more details and context about this Infrastructure potentially including its purpose and its key characteristics."
+        },
+        "infrastructure_types": {
+          "type": "array",
+          "description": "This field is an Open Vocabulary that specifies the type of infrastructure. Open vocab - infrastructure-type-ov",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "kill_chain_phases": {
+          "type": "array",
+          "description": "The list of kill chain phases for which this infrastructure is used.",
+          "items": {
+            "$ref": "../common/kill-chain-phase.json"
+          },
+          "minItems": 1
+        },
+        "first_seen": {
+          "$ref": "../common/timestamp.json",
+          "description": "The time that this infrastructure was first seen performing malicious activities."
+        },
+        "last_seen": {
+          "$ref": "../common/timestamp.json",
+          "description": "The time that this infrastructure was last seen performing malicious activities."
+        }
+      }
+    }
+  ],
+  "required": [
+    "name",
+    "infrastructure_types"
+  ],
+  "definitions": {
+    "infrastructure-type-ov": {
+      "type": "string",
+      "enum": [
+        "amplification",
+        "anonymization",
+        "botnet",
+        "command-and-control",
+        "exfiltration",
+        "hosting-malware",
+        "hosting-target-lists",
+        "phishing",
+        "reconnaissance",
+        "staging",
+        "undefined"
+      ]
+    }
+  }
+}

--- a/schemas/sdos/malware-analysis.json
+++ b/schemas/sdos/malware-analysis.json
@@ -1,0 +1,94 @@
+{
+  "id": "../sdos/malware-analysis.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "malware-analysis",
+  "description": "Malware Analysis captures the metadata and results of a particular analysis performed (static or dynamic) on the malware instance or family.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../common/core.json"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `malware-analysis`.",
+          "enum": [
+            "malware-analysis"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^malware-analysis--"
+        },
+        "product": {
+          "type": "string",
+          "description": "The name of the analysis engine or product that was used for this analysis."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the analysis product that was used to perform this analysis."
+        },
+        "configuration_version": {
+          "type": "string",
+          "description": "The version of the analysis product configuration that was used to perform this analysis."
+        },
+        "module": {
+          "type": "string",
+          "description": "The particular analysis product module that was used to perform the analysis."
+        },
+        "av_engine_version": {
+          "type": "string",
+          "description": "The version of the analysis engine or product that was used to perform this analysis."
+        },
+        "av_definition_version": {
+          "type": "string",
+          "description": "The version of the analysis definitions used by the analysis tool."
+        },
+        "submitted": {
+          "$ref": "../common/timestamp.json",
+          "description": "The date and time that this malware was first submitted for scanning or analysis."
+        },
+        "analysis_started": {
+          "$ref": "../common/timestamp.json",
+          "description": "The date and time that the malware analysis was initiated."
+        },
+        "analysis_ended": {
+          "$ref": "../common/timestamp.json",
+          "description": "The date and time that the malware analysis ended."
+        },
+        "av_result": {
+          "type": "string",
+          "description": "The classification result or name assigned to the malware instance by the AV scanner tool."
+        },
+        "host_vm": {
+          "$ref": "../common/identifier.json",
+          "description": "A description of the virtual machine environment used to host the guest operating system (if applicable) that was used for the dynamic analysis of the malware instance or family."
+        },
+        "operating_system": {
+          "$ref": "../common/identifier.json",
+          "description": "The operating system that was used to perform the dynamic analysis."
+        },
+        "installed_software": {
+          "type": "array",
+          "description": "Any non-standard software installed on the operating system used for the dynamic analysis of the malware instance or family.",
+          "items": {
+            "$ref": "../common/identifier.json"
+          },
+          "minItems": 1
+        },
+        "analysis_sco_refs": {
+          "type": "array",
+          "description": "The list of STIX objects that were captured during the analysis process.",
+          "items": {
+            "$ref": "../common/identifier.json"
+          },
+          "minItems": 1
+        }
+      }
+    }
+  ],
+  "required": [
+    "product"
+  ]
+}


### PR DESCRIPTION
Introducing schema for grouping, infrastructure, and malware-analysis objects based on STIX 2.1 WD04.

Ideally, the parent project will introduce a new branch for WD04. I'm happy to discard and resubmit the pull request if a better target becomes available. Please let me know if you would like me to do so.

Submitted under IBM's Entity CLA.