### PR TITLE
Schema updates for infrastructure examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,3 +60,8 @@
 *Completely New Example Written for 2.0*
 * Description of this example can be seen on the CTI-documentation site [here](https://oasis-open.github.io/cti-documentation/examples/using-marking-definitions).
 * Demonstrates both specification-designed marking definition types: Statement and TLP.
+
+### Infrastructure Examples
+*Completely New Example Written for 2.1*
+* This example contains the bundled form of the infrastructure examples from STIX 2.1 WD04.
+* Demonstrates how to use the new Infrastructure object.

--- a/examples/infrastructure.json
+++ b/examples/infrastructure.json
@@ -1,0 +1,112 @@
+{
+    "id": "bundle--5330e3e3-8f58-4d21-9f4b-793a054c0d33",
+    "objects": [
+        {
+            "created": "2016-05-07T11:22:30.000Z",
+            "id": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+            "infrastructure_types": [
+                "command-and-control"
+            ],
+            "labels": [
+                "command-and-control"
+            ],
+            "modified": "2016-05-07T11:22:30.000Z",
+            "name": "Poison Ivy C2",
+            "type": "infrastructure",
+	    "spec_version": "2.1"
+        },
+        {
+            "created": "2016-05-09T08:17:27.000Z",
+            "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ed",
+            "modified": "2016-05-09T08:17:27.000Z",
+            "relationship_type": "controls",
+            "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+            "target_ref": "malware--16f4f3f9-1b68-4abb-bb66-7639d49f1e30",
+            "type": "relationship",
+	    "spec_version": "2.1"
+        },
+        {
+            "created": "2016-05-08T14:31:09.000Z",
+            "id": "malware--16f4f3f9-1b68-4abb-bb66-7639d49f1e30",
+            "is_family": true,
+            "labels": [
+                "rat"
+            ],
+            "modified": "2016-05-08T14:31:09.000Z",
+            "name": "Poison Ivy",
+	    "malware_types":[
+		    "remote-access-trojan"
+	    ],
+            "type": "malware",
+	    "spec_version": "2.1"
+        },
+        {
+            "created": "2016-05-09T08:17:27.000Z",
+            "id": "relationship--7aebe2f0-28d6-48a2-9c3e-b0aaa60266ef",
+            "modified": "2016-05-09T08:17:27.000Z",
+            "relationship_type": "consists-of",
+            "source_ref": "infrastructure--38c47d93-d984-4fd9-b87b-d69d0841628d",
+            "target_ref": "ipv4-addr--1e4ffad7-0b88-41d4-ba4d-77d27490b956",
+            "type": "relationship",
+	    "spec_version": "2.1"
+        },
+        {
+            "id": "ipv4-addr--1e4ffad7-0b88-41d4-ba4d-77d27490b956",
+            "type": "ipv4-addr",
+            "value": "198.51.100.3"
+        },
+        {
+            "created": "2016-11-22T09:22:30.000Z",
+            "id": "infrastructure--d09c50cf-5bab-465e-9e2d-543912148b73",
+            "infrastructure_types": [
+                "hosting-target-lists"
+            ],
+            "labels": [
+                "target-list-hosting"
+            ],
+            "modified": "2016-11-22T09:22:30.000Z",
+            "name": "Example target-list-hosting",
+            "type": "infrastructure",
+	    "spec_version": "2.1"
+        },
+        {
+            "created": "2016-11-23T08:17:27.000Z",
+            "id": "relationship--37ac0c8d-f86d-4e56-aee9-914343959a4c",
+            "modified": "2016-11-23T08:17:27.000Z",
+            "relationship_type": "uses",
+            "source_ref": "malware--3a41e552-999b-4ad3-bedc-332b6d9ff80c",
+            "target_ref": "infrastructure--d09c50cf-5bab-465e-9e2d-543912148b73",
+            "type": "relationship",
+	    "spec_version": "2.1"
+        },
+        {
+            "created": "2016-11-12T14:31:09.000Z",
+            "id": "malware--3a41e552-999b-4ad3-bedc-332b6d9ff80c",
+            "is_family": true,
+            "modified": "2016-11-12T14:31:09.000Z",
+            "name": "IMDDOS",
+            "type": "malware",
+	    "malware_types":[
+		    "bot"
+	    ],
+
+	    "spec_version": "2.1"
+        },
+        {
+            "created": "2016-11-23T10:42:39.000Z",
+            "id": "relationship--81f12913-1372-4c96-85ec-E9034ac98aba",
+            "modified": "2016-11-23T10:42:39.000Z",
+            "relationship_type": "consists-of",
+            "source_ref": "infrastructure--d09c50cf-5bab-465e-9e2d-543912148b73",
+            "target_ref": "domain-name--ecb120bf-2694-4902-a737-62b74539a41b",
+            "type": "relationship",
+	    "spec_version": "2.1"
+        },
+        {
+            "id": "domain-name--ecb120bf-2694-4902-a737-62b74539a41b",
+            "type": "domain-name",
+            "value": "example.com"
+        }
+    ],
+    "type": "bundle"
+}

--- a/schemas/common/cyber-observable-core.json
+++ b/schemas/common/cyber-observable-core.json
@@ -17,6 +17,10 @@
         ]
       }
     },
+    "id": {
+      "$ref": "identifier.json",
+      "description": "Specifies the identifier of the observable object, as a string."
+    },
     "extensions": {
       "$ref": "dictionary.json",
       "description": "Specifies any extensions of the object, as a dictionary."
@@ -52,6 +56,7 @@
   },
   "additionalProperties": false,
   "required": [
-    "type"
+    "type",
+    "id"
   ]
 }

--- a/schemas/observables/artifact.json
+++ b/schemas/observables/artifact.json
@@ -17,6 +17,10 @@
             "artifact"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^artifact--"
+        },
         "mime_type": {
           "type": "string",
           "pattern": "^(application|audio|font|image|message|model|multipart|text|video)/[a-zA-Z0-9.+_-]+",

--- a/schemas/observables/autonomous-system.json
+++ b/schemas/observables/autonomous-system.json
@@ -17,6 +17,10 @@
             "autonomous-system"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^autonomous-system--"
+        },
         "number": {
           "type": "integer",
           "description": "Specifies the number assigned to the AS. Such assignments are typically performed by a Regional Internet Registries (RIR)."

--- a/schemas/observables/directory.json
+++ b/schemas/observables/directory.json
@@ -17,6 +17,11 @@
             "directory"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^directory--"
+        },
+
         "path": {
           "type": "string",
           "description": "Specifies the path, as originally observed, to the directory on the file system."

--- a/schemas/observables/domain-name.json
+++ b/schemas/observables/domain-name.json
@@ -17,6 +17,10 @@
             "domain-name"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^domain-name--"
+        },
         "value": {
           "type": "string",
           "description": "Specifies the value of the domain name."

--- a/schemas/observables/email-addr.json
+++ b/schemas/observables/email-addr.json
@@ -17,6 +17,10 @@
             "email-addr"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^email-addr--"
+        },
         "value": {
           "type": "string",
           "pattern": "(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$)",

--- a/schemas/observables/email-message.json
+++ b/schemas/observables/email-message.json
@@ -17,6 +17,10 @@
             "email-message"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^email-message--"
+        },
         "date": {
           "$ref": "../common/timestamp.json",
           "description": "Specifies the date/time that the email message was sent."

--- a/schemas/observables/file.json
+++ b/schemas/observables/file.json
@@ -17,6 +17,10 @@
             "file"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^file--"
+        },
         "extensions": {
           "$ref": "#/definitions/file-extensions-dictionary",
           "description": "The File Object defines the following extensions. In addition to these, producers MAY create their own. Extensions: ntfs-ext, raster-image-ext, pdf-ext, archive-ext, windows-pebinary-ext"

--- a/schemas/observables/ipv4-addr.json
+++ b/schemas/observables/ipv4-addr.json
@@ -17,6 +17,10 @@
             "ipv4-addr"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^ipv4-addr--"
+        },
         "value": {
           "type": "string",
           "description": "Specifies one or more IPv4 addresses expressed using CIDR notation."

--- a/schemas/observables/ipv6-addr.json
+++ b/schemas/observables/ipv6-addr.json
@@ -17,6 +17,10 @@
             "ipv6-addr"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^ipv6-addr--"
+        },
         "value": {
           "type": "string",
           "description": "Specifies one or more IPv6 addresses expressed using CIDR notation."

--- a/schemas/observables/mac-addr.json
+++ b/schemas/observables/mac-addr.json
@@ -17,6 +17,10 @@
             "mac-addr"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^mac-addr--"
+        },
         "value": {
           "type": "string",
           "pattern": "^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$",

--- a/schemas/observables/mutex.json
+++ b/schemas/observables/mutex.json
@@ -17,6 +17,10 @@
             "mutex"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^mutex--"
+        },
         "name": {
           "type": "string",
           "description": "Specifies the name of the mutex object."

--- a/schemas/observables/network-traffic.json
+++ b/schemas/observables/network-traffic.json
@@ -17,6 +17,10 @@
             "network-traffic"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^network-traffic--"
+        },
         "extensions": {
           "$ref": "#/definitions/network-traffic-extensions-dictionary",
           "description": "The Network Traffic Object defines the following extensions. In addition to these, producers MAY create their own. Extensions: http-ext, tcp-ext, icmp-ext, socket-ext"

--- a/schemas/observables/process.json
+++ b/schemas/observables/process.json
@@ -17,6 +17,10 @@
             "process"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^process--"
+        },
         "extensions": {
           "$ref": "#/definitions/process-extensions-dictionary",
           "description": "The Process Object defines the following extensions. In addition to these, producers MAY create their own. Extensions: windows-process-ext, windows-service-ext."

--- a/schemas/observables/software.json
+++ b/schemas/observables/software.json
@@ -17,6 +17,10 @@
             "software"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^software--"
+        },
         "name": {
           "type": "string",
           "description": "Specifies the name of the software."

--- a/schemas/observables/url.json
+++ b/schemas/observables/url.json
@@ -17,6 +17,10 @@
             "url"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^url--"
+        },
         "value": {
           "$ref": "../common/url-regex.json",
           "description": "Specifies the value of the URL."

--- a/schemas/observables/user-account.json
+++ b/schemas/observables/user-account.json
@@ -17,6 +17,10 @@
             "user-account"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^user-account--"
+        },
         "extensions": {
           "$ref": "#/definitions/user-account-extensions-dictionary",
           "description": "The User Account Object defines the following extensions. In addition to these, producers MAY create their own. Extensions: unix-account-ext."

--- a/schemas/observables/windows-registry-key.json
+++ b/schemas/observables/windows-registry-key.json
@@ -17,6 +17,10 @@
             "windows-registry-key"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^windows-registry-key--"
+        },
         "key": {
           "type": "string",
           "pattern": "^HKEY_LOCAL_MACHINE|hkey_local_machine|HKEY_CURRENT_USER|hkey_current_user|HKEY_CLASSES_ROOT|hkey_classes_root|HKEY_CURRENT_CONFIG|hkey_current_config|HKEY_PERFORMANCE_DATA|hkey_performance_data|HKEY_USERS|hkey_users|HKEY_DYN_DATA|hkey_dyn_data",

--- a/schemas/observables/x509-certificate.json
+++ b/schemas/observables/x509-certificate.json
@@ -17,6 +17,10 @@
             "x509-certificate"
           ]
         },
+        "id": {
+          "title": "id",
+          "pattern": "^x509-certificate--"
+        },
         "is_self_signed": {
           "type": "boolean",
           "description": "Specifies whether the certificate is self-signed, i.e., whether it is signed by the same entity whose identity it certifies."

--- a/schemas/sdos/infrastructure.json
+++ b/schemas/sdos/infrastructure.json
@@ -39,7 +39,7 @@
         },
         "aliases": {
           "type": "array",
-          "description": "This field contains a description that provides more details and context about the Infrastructure",
+          "description": "Alternative names used to identify this Infrastructure.",
           "items": {
             "type": "string"
           },

--- a/schemas/sdos/infrastructure.json
+++ b/schemas/sdos/infrastructure.json
@@ -37,6 +37,14 @@
           },
           "minItems": 1
         },
+        "aliases": {
+          "type": "array",
+          "description": "This field contains a description that provides more details and context about the Infrastructure",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
         "kill_chain_phases": {
           "type": "array",
           "description": "The list of kill chain phases for which this infrastructure is used.",


### PR DESCRIPTION
In STIX 2.1 WD04, id is a required property for SCOs and the Infrastructure examples use the id field to express relationships. This pull request adds the id property to the SCOs. It also adds some of the infrastructure examples from STIX 2.1 WD04 to the examples directory to test the update. Finally, it adds the new aliases property to the Infrastructure object.

I have signed the CLA.