### PR TITLE
add `id` as special-case option in regex for selector syntax

### DIFF
--- a/schemas/common/granular-marking.json
+++ b/schemas/common/granular-marking.json
@@ -10,7 +10,7 @@
       "description": "A list of selectors for content contained within the STIX object in which this property appears.",
       "items": {
         "type": "string",
-        "pattern": "^[a-z][a-z0-9_-]{3,249}(\\.(\\[\\d+\\]|[a-z0-9_-]{1,250}))*$"
+        "pattern": "^([a-z0-9_-]{3,249}(\\.(\\[\\d+\\]|[a-z0-9_-]{1,250}))*|id)$"
       },
       "minItems": 1
     },


### PR DESCRIPTION
It would cause the validator to mark content as invalid...