### PR TITLE
Fix JSON schema for windows-registry-key SCO for hive names

### DIFF
--- a/schemas/observables/windows-registry-key.json
+++ b/schemas/observables/windows-registry-key.json
@@ -23,7 +23,7 @@
         },
         "key": {
           "type": "string",
-          "pattern": "^HKEY_LOCAL_MACHINE|hkey_local_machine|HKEY_CURRENT_USER|hkey_current_user|HKEY_CLASSES_ROOT|hkey_classes_root|HKEY_CURRENT_CONFIG|hkey_current_config|HKEY_PERFORMANCE_DATA|hkey_performance_data|HKEY_USERS|hkey_users|HKEY_DYN_DATA|hkey_dyn_data",
+          "not": {"pattern": "^HKLM|HKCC|HKCR|HKCU|HKU|hklm|hkcc|hkcr|hkcu|hku"},
           "description": "Specifies the full registry key including the hive."
         },
         "values": {


### PR DESCRIPTION
This changes the whitelist regex on non-abbreviated hive names to a blacklist regex on abbreviated hive names.  I found some abbreviated hive names at https://en.wikipedia.org/wiki/Windows_Registry .  It includes HKLM, HKCC, HKCR, HKCU, HKU, so those are the values used in the schema.  I retained both lower and uppercase versions, since that's how the previous regex was written.

Fixes #143 .
Also fixes https://github.com/oasis-open/cti-stix-validator/issues/185 .
Also fixes https://github.com/oasis-open/cti-stix-generator/issues/19 .