### PR TITLE
Correct schema for network-traffic http-request-ext request_header

### DIFF
--- a/schemas/observables/network-traffic.json
+++ b/schemas/observables/network-traffic.json
@@ -198,7 +198,10 @@
               "description": "Specifies all of the HTTP header fields that may be found in the HTTP client request, as a dictionary.",
               "patternProperties": {
                 "^.+$": {
-                  "type": "string"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
The STIX2.1 standard states for network-traffic http-request-ext
request_header:

> The corresponding value for each dictionary key MUST always be a list
of type string to support when a header field is repeated.

The JSON schema now adheres to that specification.

Closes #152 