### PR TITLE
Fix exists grammar

### DIFF
--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -50,7 +50,7 @@ propTest
   | objectPath NOT? ISSUBSET StringLiteral          # propTestIsSubset
   | objectPath NOT? ISSUPERSET StringLiteral        # propTestIsSuperset
   | LPAREN comparisonExpression RPAREN              # propTestParen
-  | NOT? EXISTS objectPath                               # propTestExists
+  | NOT? EXISTS objectPath                          # propTestExists
   ;
 
 startStopQualifier

--- a/pattern_grammar/STIXPattern.g4
+++ b/pattern_grammar/STIXPattern.g4
@@ -50,7 +50,7 @@ propTest
   | objectPath NOT? ISSUBSET StringLiteral          # propTestIsSubset
   | objectPath NOT? ISSUPERSET StringLiteral        # propTestIsSuperset
   | LPAREN comparisonExpression RPAREN              # propTestParen
-  | EXISTS objectPath                               # propTestExists
+  | NOT? EXISTS objectPath                               # propTestExists
   ;
 
 startStopQualifier


### PR DESCRIPTION
The standard states that:

> A Comparison Operator MAY be preceded by the modifier NOT, in which case the resultant Comparison Expression is logically negated.

and the `EXISTS` set operator is defined under the comparison operators (together with `ISSUBSET` and `ISSUPERSET` under the set operators). I'm guessing the specification for the not syntax with set operators was missed when exists was added with stix 2.1 which introduced it.

This PR should make set operators consistent with the spec.

Closes #157 