### PR TITLE
fixed small typo in malware.json

### DIFF
--- a/schemas/sdos/malware.json
+++ b/schemas/sdos/malware.json
@@ -54,7 +54,7 @@
         },
         "architecture_execution_envs" : {
           "type" : "array",
-          "description": "The processor architectures (e.g., x86, ARM, etc.) that the malware instance or family is executable on. Open Vocab - processor-architecture-os.",
+          "description": "The processor architectures (e.g., x86, ARM, etc.) that the malware instance or family is executable on. Open Vocab - processor-architecture-ov.",
           "items" : {
             "type" : "string"
           },


### PR DESCRIPTION
The description for architecture_execution_envs has a typo with "processor-architecture-ov", which was incorrectly spelled as "processor-architecture-os"