### PR TITLE
Adds allow/deny to object_refs to prevent SDOs as refs in observed data

### DIFF
--- a/schemas/sdos/observed-data.json
+++ b/schemas/sdos/observed-data.json
@@ -123,7 +123,24 @@
           "type": "array",
           "description": "A list of SCOs and SROs representing the observation.",
           "items": {
-            "$ref": "../common/identifier.json"
+            "type" : "string",
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "../common/identifier.json"
+                  },
+                  {
+                    "not": {
+                      "pattern": "^(attack-pattern|campaign|course-of-action|grouping|identity|incident|indicator|infrastructure|intrusion-set|location|malware-analysis|malware|note|observed-data|opinion|report|threat-actor|tool|vulnerability)"
+                    }
+                  }
+                ]
+              },
+              {
+                "pattern": "^(autonomous-system--|directory--|domain-name--|email-addr--|email-message--|file--|ipv4-addr--|ipv6-addr--|mac-addr--|mutex--|network-traffic--|process--|software--|url--|user-account--|windows-registry-key--|x509-certificate--|relationship--|sighting--)"
+              }
+            ]
           },
           "minItems": 1
         }


### PR DESCRIPTION
Addresses [Validator issue #182](https://github.com/oasis-open/cti-stix-validator/issues/182).  Adds a check for SDO object name patterns to the object_refs to deny.  Allows SCO and SRO refs.  
NOTE: Validator submodule links need correcting to match this update.
See also added Test in Validator to confirm allow/deny:
stix2validator/test/v21/observed_data_tests.py::ObservedDataTestCases::test_invalid_object_refs