### PR TITLE
Update the schema for the software object languages property change between CS02 and CS03

### DIFF
--- a/schemas/observables/software.json
+++ b/schemas/observables/software.json
@@ -36,10 +36,10 @@
         },
         "languages": {
           "type": "array",
-          "description": "Specifies the languages supported by the software. The value of each list member MUST be an ISO 639-2 language code.",
+          "description": "Specifies the languages supported by the software. The value of each list member MUST be an RFC 5646 language code. ISO 639-2 codes are accepted for backward compatibility.",
           "items": {
             "type": "string",
-            "pattern": "^[a-z]{3}$"
+            "pattern": "^([a-z]{2}(-[A-Z]{2})?(-[a-z]{4})?(-[A-Z]{2}|[0-9]{3})?(-[a-z0-9]{5,8}|[0-9][a-z0-9]{3})*(-[a-z0-9]{1,8})*|[a-z]{3})$"
           },
           "minItems": 1
         },


### PR DESCRIPTION
This is the counterpart to the stix-validator change: https://github.com/oasis-open/cti-stix-validator/pull/243

This changes the schema to allow both ISO 639-2 and RFC 5646 languages. I added this to the stix-validator for backwards compatibility, but since it requires a change to the schema, I think this needs some discussion and consideration.

RIght now the schema requires the 3 letter codes of ISO 639-2 which doesn't match STIX 2.1 CS03 but does match STIX 2.1 CS02. After this patch, it will accept both ISO 639-2 and RFC 5646. (RFC 5646 is required by STIX 2.1 CS03). So objects that adhere to either CS will be allowed through rather than only those that match the latest spec.

Open to suggestions here.