### PR TITLE
Introduce malicious LLM Prompts to STIX Standard as Observable Object to be used as Indicator pattern for IOCs

### DIFF
--- a/schemas/observables/llm-prompt.json
+++ b/schemas/observables/llm-prompt.json
@@ -24,7 +24,7 @@
         "content": {
           "type": "string",
           "description": "Specifies the LLM Prompt content using Natural Language Instructions."
-        },
+        }
       },
       "required": [
         "content"

--- a/schemas/observables/llm-prompt.json
+++ b/schemas/observables/llm-prompt.json
@@ -21,13 +21,13 @@
           "title": "id",
           "pattern": "^llm-prompt--"
         },
-        "content": {
+        "value": {
           "type": "string",
           "description": "Specifies the LLM Prompt content using Natural Language Instructions."
         }
       },
       "required": [
-        "content"
+        "value"
       ]
     }
   ]

--- a/schemas/observables/llm-prompt.json
+++ b/schemas/observables/llm-prompt.json
@@ -1,0 +1,34 @@
+{
+  "$id": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/observables/llm-prompt.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "llm-prompt",
+  "description": "The LLM Prompt Object represents a single LLM Prompt expressed using Natural Language Instructions.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../common/cyber-observable-core.json"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The value of this property MUST be `llm-prompt`.",
+          "enum": [
+            "llm-prompt"
+          ]
+        },
+        "id": {
+          "title": "id",
+          "pattern": "^llm-prompt--"
+        },
+        "content": {
+          "type": "string",
+          "description": "Specifies the LLM Prompt content using Natural Language Instructions."
+        },
+      },
+      "required": [
+        "content"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Using this PR I like to propose the discussion introducing LLM Prompts as pattern type for Indicators. Many domain experts see the growth of evil prompts. From solely LLM, MCP towards AI Agents. Within the world of LLM Observability we already match undesired prompts and many Security analysts are debating for this type of IOC, like https://novahunting.ai/. 

Let's support the community detecting adversarial prompts using matching IOCs !

Would be great to have such object introduced in the STIX standard.
