### PR TITLE
Merge updates from master branch into stix2.1 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Initially, the associated TC members have designated one or more persons to serv
 
 **<a id="currentMaintainers">Current Maintainers of this TC Open Repository</a>**
 
- * [Jason Keirstead](mailto:Jason.Keirstead@ca.ibm.com); GitHub ID: [https://github.com/JasonKeirstead](https://github.com/JasonKeirstead); WWW: [IBM](http://www.ibm.com/)
  * [Emily Ratliff](mailto:Emily.Ratliff@ibm.com); GitHub ID: [https://github.com/ejratl](https://github.com/ejratl); WWW: [IBM](http://www.ibm.com/)
  * [Rich Piazza](mailto:rpiazza@mitre.org); GitHub ID: [https://github.com/rpiazza](https://github.com/rpiazza) WWW: [MITRE](http://www.mitre.org/)
+* [Alexandre Dulaunoy](mailto:alexandre.dulaunoy@circl.lu); GitHub ID: [https://github.com/adulau](https://github.com/adulau); WWW: [CIRCL](http://www.circl.lu/)
+* [Christian Studer](mailto:christian.studer@circl.lu); GitHub ID: [https://github.com/chrisr3d](https://github.com/chrisr3d); WWW: [CIRCL](http://www.circl.lu/)
 
 ## <a id="aboutOpenRepos">About OASIS TC Open Repositories</a>
 

--- a/schemas/observables/software.json
+++ b/schemas/observables/software.json
@@ -36,10 +36,10 @@
         },
         "languages": {
           "type": "array",
-          "description": "Specifies the languages supported by the software. The value of each list member MUST be an ISO 639-2 language code.",
+          "description": "Specifies the languages supported by the software. The value of each list member MUST be an RFC 5646 language code. ISO 639-2 codes are accepted for backward compatibility.",
           "items": {
             "type": "string",
-            "pattern": "^[a-z]{3}$"
+            "pattern": "^([a-z]{2}(-[A-Z]{2})?(-[a-z]{4})?(-[A-Z]{2}|[0-9]{3})?(-[a-z0-9]{5,8}|[0-9][a-z0-9]{3})*(-[a-z0-9]{1,8})*|[a-z]{3})$"
           },
           "minItems": 1
         },


### PR DESCRIPTION
It turns out that it is not sufficient to merge changes into master if the stix validator relies on them because the default instructions cause the cti-stix2-json-schemas repo which is a git submodule of the stix validator to switch to the stix2.1 branch. So this PR is needed before https://github.com/oasis-open/cti-stix-validator/pull/243 can be merged.